### PR TITLE
feat: add Google Tag Manager (GTM-WLW7MGVQ) via next/script

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,12 @@
 import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import ScrollToTop from "@/components/portfolio/ScrollToTop";
 import HangingLamp from "@/components/portfolio/HangingLamp";
 import { ThemeProvider } from "@/components/portfolio/ThemeProvider";
 import "./globals.css";
+
+const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID || "GTM-WLW7MGVQ";
 
 const inter = Inter({
   variable: "--font-sans",
@@ -36,7 +39,27 @@ export default function RootLayout({
       className={`${inter.variable} h-full`}
       suppressHydrationWarning
     >
+      <head>
+        {/* Google Tag Manager */}
+        <Script id="gtm-init" strategy="afterInteractive">
+          {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${GTM_ID}');`}
+        </Script>
+      </head>
       <body className="min-h-full">
+        {/* Google Tag Manager (noscript) */}
+        <noscript>
+          <iframe
+            src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
+            height="0"
+            width="0"
+            style={{ display: "none", visibility: "hidden" }}
+            title="Google Tag Manager"
+          />
+        </noscript>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           {children}
           <ScrollToTop />


### PR DESCRIPTION
Injects the GTM init snippet in <head> using next/script afterInteractive strategy and adds the <noscript> iframe fallback in <body>. Container ID reads from NEXT_PUBLIC_GTM_ID env var with the production ID as default.